### PR TITLE
Added abortAll() to abort any pending requests, including blocking ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ if (item)
     std::cout << item.key << "=" << item.value << "\n";
 ```
 
+Abort blocking queries:
+
+```cpp
+Consul consul(kw::enable_stop = true); // Must be enabled at construction time
+Kv kv(consul);
+
+// Issue blocking queries, similarly to example above, on background threads etc.
+
+// Stop all pending requests, e.g. at shutdown. Also prevents any future ones being initiated.
+consul.stop();
+```
+
 Connect to Consul via HTTPS (TLS/SSL, whatever you call it):
 
 ```cpp

--- a/include/ppconsul/error.h
+++ b/include/ppconsul/error.h
@@ -15,7 +15,7 @@ namespace ppconsul {
 
     class Error: public std::exception {};
 
-    class FormatError: public ppconsul::Error
+    class FormatError: public Error
     {
     public:
         FormatError(std::string message)
@@ -26,6 +26,14 @@ namespace ppconsul {
 
     private:
         std::string m_message;
+    };
+
+    class OperationAborted: public Error
+    {
+    public:
+        OperationAborted() = default;
+
+        virtual const char *what() const PPCONSUL_NOEXCEPT override { return "Operation aborted"; }
     };
 
     class BadStatus: public Error

--- a/include/ppconsul/http_client.h
+++ b/include/ppconsul/http_client.h
@@ -46,6 +46,8 @@ namespace ppconsul { namespace http { namespace impl {
         // Returns {status, body}
         virtual std::pair<Status, std::string> del(const std::string& path, const std::string& query) = 0;
 
+        virtual void stop() = 0;
+
         virtual ~Client() {};
     };
 

--- a/src/consul.cpp
+++ b/src/consul.cpp
@@ -36,8 +36,9 @@ namespace ppconsul {
         return m_what.c_str();
     }
 
-    Consul::Consul(const std::string& defaultToken, const std::string& dataCenter, const std::string& endpoint, const http::impl::TlsConfig& tlsConfig)
-    : m_client(new impl::HttpClient(helpers::ensureScheme(endpoint), tlsConfig))
+    Consul::Consul(const std::string& defaultToken, const std::string& dataCenter, const std::string& endpoint,
+                   const http::impl::TlsConfig& tlsConfig, bool enableStop)
+    : m_client(new impl::HttpClient(helpers::ensureScheme(endpoint), tlsConfig, enableStop))
     , m_dataCenter(dataCenter)
     , m_defaultToken(defaultToken)
     {}

--- a/src/curl/http_client.cpp
+++ b/src/curl/http_client.cpp
@@ -80,7 +80,10 @@ namespace ppconsul { namespace curl {
 
         void throwCurlError(CURLcode code, const char *err)
         {
-            throw std::runtime_error(std::string(err) + " (" + std::to_string(code) + ")");
+            if (code == CURLE_ABORTED_BY_CALLBACK)
+                throw ppconsul::OperationAborted();
+            else
+                throw std::runtime_error(std::string(err) + " (" + std::to_string(code) + ")");
         }
 
         enum { Buffer_Size = 16384 };
@@ -139,10 +142,18 @@ namespace ppconsul { namespace curl {
             ctx->second += size;
             return size;
         }
+
+        int progressCallback(void *clientPtr, curl_off_t, curl_off_t, curl_off_t, curl_off_t)
+        {
+            const auto* client = static_cast<const HttpClient*>(clientPtr);
+            return client->isStopped();
+        }
     }
 
-    HttpClient::HttpClient(const std::string& endpoint)
+    HttpClient::HttpClient(const std::string& endpoint, const TlsConfig& tlsConfig, bool enableStop)
     : m_endpoint(endpoint)
+    , m_enableStop(enableStop)
+    , m_stopped(false)
     {
         static const CurlInitializer g_initialized;
 
@@ -156,14 +167,25 @@ namespace ppconsul { namespace curl {
         if (auto err = curl_easy_setopt(handle(), CURLOPT_ERRORBUFFER, m_errBuffer))
             throwCurlError(err, "");
 
+        if (m_enableStop)
+        {
+            setopt(CURLOPT_NOPROGRESS, 0l);
+            setopt(CURLOPT_XFERINFOFUNCTION, &progressCallback);
+            setopt(CURLOPT_XFERINFODATA, this);
+        }
+        else
+        {
+            setopt(CURLOPT_NOPROGRESS, 1l);
+        }
+
         // TODO: CURLOPT_NOSIGNAL?
-        setopt(CURLOPT_NOPROGRESS, 1l);
         setopt(CURLOPT_WRITEFUNCTION, &writeCallback);
         setopt(CURLOPT_READFUNCTION, &readCallback);
+
+        setupTls(tlsConfig);
     }
 
-    HttpClient::HttpClient(const std::string& endpoint, const TlsConfig& tlsConfig)
-    : HttpClient(endpoint)
+    void HttpClient::setupTls(const TlsConfig& tlsConfig)
     {
         if (!tlsConfig.cert.empty())
             setopt(CURLOPT_SSLCERT, tlsConfig.cert.c_str());
@@ -249,6 +271,13 @@ namespace ppconsul { namespace curl {
         return r;
     }
 
+    void HttpClient::stop()
+    {
+        if (!m_enableStop)
+            throw std::logic_error("Must enable stop at construction time");
+        m_stopped.store(true, std::memory_order_relaxed);
+    }
+
     template<class Opt, class T>
     inline void HttpClient::setopt(Opt opt, const T& t)
     {
@@ -256,7 +285,6 @@ namespace ppconsul { namespace curl {
         if (err)
             throwCurlError(err, m_errBuffer);
     }
-
 
     inline void HttpClient::perform()
     {

--- a/src/curl/http_client.h
+++ b/src/curl/http_client.h
@@ -10,6 +10,7 @@
 #include "http_helpers.h"
 #include <curl/curl.h>
 #include <memory>
+#include <atomic>
 
 
 namespace ppconsul { namespace curl {
@@ -30,8 +31,7 @@ namespace ppconsul { namespace curl {
     public:
         using GetResponse = std::tuple<http::Status, ResponseHeaders, std::string>;
 
-        HttpClient(const std::string& endpoint);
-        HttpClient(const std::string& endpoint, const ppconsul::http::impl::TlsConfig& tlsConfig);
+        HttpClient(const std::string& endpoint, const ppconsul::http::impl::TlsConfig& tlsConfig, bool enableStop);
 
         virtual ~HttpClient() override;
 
@@ -39,12 +39,17 @@ namespace ppconsul { namespace curl {
         std::pair<http::Status, std::string> put(const std::string& path, const std::string& query, const std::string& data) override;
         std::pair<http::Status, std::string> del(const std::string& path, const std::string& query) override;
 
+        void stop() override;
+        bool isStopped() const { return m_stopped.load(std::memory_order_relaxed); }
+
         HttpClient(const HttpClient&) = delete;
         HttpClient(HttpClient&&) = delete;
         HttpClient& operator= (const HttpClient&) = delete;
         HttpClient& operator= (HttpClient&&) = delete;
 
     private:
+        void setupTls(const ppconsul::http::impl::TlsConfig& tlsConfig);
+
         template<class Opt, class T>
         void setopt(Opt opt, const T& t);
 
@@ -57,6 +62,8 @@ namespace ppconsul { namespace curl {
         std::string m_endpoint;
         std::unique_ptr<CURL, detail::CurlEasyDeleter> m_handle;
         char m_errBuffer[CURL_ERROR_SIZE]; // Replace with unique_ptr<std::array<char, CURL_ERROR_SIZE>> if moving is needed
+        bool m_enableStop;
+        std::atomic_bool m_stopped;
     };
 
 }}

--- a/tests/kv/CMakeLists.txt
+++ b/tests/kv/CMakeLists.txt
@@ -10,4 +10,6 @@ add_executable(${PROJECT_NAME}
     kv_tests.cpp
 )
 link_test_libs(${PROJECT_NAME})
+find_package(Threads)
+target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 add_catch_test(${PROJECT_NAME})

--- a/tests/test_consul.h
+++ b/tests/test_consul.h
@@ -11,12 +11,16 @@ inline std::string get_test_datacenter()
     return datacenter ? datacenter : "ppconsul_test";
 }
 
-inline ppconsul::Consul create_test_consul()
+template<class... AdditionalParams>
+inline ppconsul::Consul create_test_consul(AdditionalParams&&... additionalParams)
 {
     auto addr = std::getenv("PPCONSUL_TEST_ADDR");
 
-    return ppconsul::Consul(addr ? addr : ppconsul::Default_Server_Endpoint,
-        ppconsul::kw::dc = get_test_datacenter());
+    return ppconsul::Consul(
+        addr ? addr : ppconsul::Default_Server_Endpoint,
+        ppconsul::kw::dc = get_test_datacenter(),
+        std::forward<AdditionalParams>(additionalParams)...
+    );
 }
 
 inline std::string get_test_leader()


### PR DESCRIPTION
This is intended to address #28.

I went with the method name `abortAll()` rather than `abort()` as it affects all pending requests. Otherwise, I generally followed the approach outlined in that issue.

A couple of other notes:
- I didn't bother adding an implementation to the `netlib` client, as I understand that this is on the way out and I don't think that the existing code still compiles anyway.
- I considered making support for aborting requests optional, so that there's not a callback being redundantly (and potentially very frequently) called if it's not required. Let me know if you would prefer this.