### PR TITLE
Set -fPIC for clang too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
         message(STATUS "GCC ${GCC_VERSION} found. Note that using of GCC version less then 4.9 requires to link with Boost.Regex library")
     endif()
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -ftemplate-depth=256")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -ftemplate-depth=256")
 elseif (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 


### PR DESCRIPTION
This seems to be necessary under Linux. (It's not under macOS, where of course clang is the default compiler and PIC is the default behaviour, but it's still ok to explicitly/redundantly turn it on there.)