### PR TITLE
sessions: allow passing zero lockDelay

### DIFF
--- a/src/sessions.cpp
+++ b/src/sessions.cpp
@@ -37,13 +37,13 @@ namespace ppconsul { namespace sessions {
         std::string createBodyJson(const std::string &node, std::chrono::seconds lockDelay,
                                    InvalidationBehavior behavior, std::chrono::seconds ttl)
         {
-            s11n::Json::object obj{{"Behavior", encodeBehavior(behavior)}};
+            s11n::Json::object obj{
+                {"Behavior", encodeBehavior(behavior)},
+                {"LockDelay", std::to_string(lockDelay.count()) + "s"},
+            };
 
             if (!node.empty())
                 obj["Node"] = node;
-
-            if (lockDelay.count())
-                obj["LockDelay"] = std::to_string(lockDelay.count()) + "s";
 
             if (ttl.count())
                 obj["TTL"] = std::to_string(ttl.count()) + "s";


### PR DESCRIPTION
Consul’s docs are inconsistent about this:

https://www.consul.io/docs/internals/sessions.html
> While the default is to use a 15 second delay, **clients are able to disable this mechanism by providing a zero delay value.**

https://www.consul.io/api/session.html#lockdelay
> LockDelay (string: "15s") - Specifies the duration for the lock delay. **This must be greater than 0.**

And consul has a couple of issues open about this:
* https://github.com/hashicorp/consul/issues/4508
* https://github.com/hashicorp/consul/issues/1077

But, surprisingly, Consul 1.5.0 understands `lockDelay=0` as expected, that is, disables the lock delay mechanism for the session.