### PR TITLE
Fix base64 encoding of long strings

### DIFF
--- a/ext/b64/cencode.c
+++ b/ext/b64/cencode.c
@@ -7,13 +7,10 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include <b64/cencode.h>
 
-const int CHARS_PER_LINE = 72;
-
 void base64_init_encodestate(base64_encodestate* state_in)
 {
 	state_in->step = step_A;
 	state_in->result = 0;
-	state_in->stepcount = 0;
 }
 
 char base64_encode_value(char value_in)
@@ -71,13 +68,6 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			*codechar++ = base64_encode_value(result);
 			result  = (fragment & 0x03f) >> 0;
 			*codechar++ = base64_encode_value(result);
-			
-			++(state_in->stepcount);
-			if (state_in->stepcount == CHARS_PER_LINE/4)
-			{
-				*codechar++ = '\n';
-				state_in->stepcount = 0;
-			}
 		}
 	}
 	/* control should not reach here */
@@ -102,7 +92,6 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\n';
 	
 	return codechar - code_out;
 }

--- a/ext/b64/cencode.h
+++ b/ext/b64/cencode.h
@@ -17,7 +17,6 @@ typedef struct
 {
 	base64_encodestep step;
 	char result;
-	int stepcount;
 } base64_encodestate;
 
 void base64_init_encodestate(base64_encodestate* state_in);

--- a/tests/unittests/helpers.cpp
+++ b/tests/unittests/helpers.cpp
@@ -40,6 +40,14 @@ TEST_CASE("helpers.base64encode", "[base64]")
     CHECK(encodeBase64("s") == "cw==");
     CHECK(encodeBase64("bla-bl") == "YmxhLWJs");
     CHECK(encodeBase64("bla-bla") == "YmxhLWJsYQ==");
+
+    {
+        const auto ntriples = 22000;
+        CHECK(
+            encodeBase64(
+                std::string(ntriples * 3, '\0')) ==
+            std::string(ntriples * 4, 'A'));
+    }
 }
 
 TEST_CASE("helpers.url encode", "[url]")


### PR DESCRIPTION
ppconsul::helpers::encodeBase64() did not account for the fact that
base64_encode_block() adds line breaks every 72 symbols or so. Let's
just remove this "feature" from base64_encode_block().