### PR TITLE
client pool failing on assert statment

### DIFF
--- a/include/ppconsul/client_pool.h
+++ b/include/ppconsul/client_pool.h
@@ -6,7 +6,7 @@
 #include <functional>
 #include <utility>
 #include <memory>
-
+#include <cassert>
 
 namespace ppconsul {
 


### PR DESCRIPTION
when I compile the most recent updates I get a compile failure:

` ppconsul/src/client_pool.cpp:24:22: error: ‘assert’ was not declared in this scope`



