### PR TITLE
Add config loading on Self request

### DIFF
--- a/include/ppconsul/agent.h
+++ b/include/ppconsul/agent.h
@@ -34,7 +34,15 @@ namespace ppconsul { namespace agent {
         int delegateCur = 0;
     };
 
-    struct Config {}; // TODO: use boost::ptree
+    struct Config
+    {
+        std::string datacenter;
+        std::string nodeName;
+        std::string nodeId;
+        bool server;
+        std::string revision;
+        std::string version;
+    };
 
     struct TtlCheck
     {

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -8,7 +8,6 @@
 #include "ppconsul/agent.h"
 #include "s11n_types.h"
 
-
 namespace json11 {
     inline void load(const json11::Json& src, std::pair<ppconsul::agent::Config, ppconsul::agent::Member>& dst)
     {
@@ -25,7 +24,12 @@ namespace ppconsul { namespace agent {
 
     void load(const s11n::Json& src, Config& dst)
     {
-        // TODO
+        load(src, dst.datacenter, "Datacenter");
+        load(src, dst.nodeName, "NodeName");
+        load(src, dst.nodeId, "NodeID");
+        load(src, dst.server, "Server");
+        load(src, dst.revision, "Revision");
+        load(src, dst.version, "Version");
     }
 
     void load(const s11n::Json& src, Member& dst)

--- a/tests/agent/agent_other_tests.cpp
+++ b/tests/agent/agent_other_tests.cpp
@@ -27,7 +27,15 @@ TEST_CASE("agent.self", "[consul][agent][config][self]")
     auto consul = create_test_consul();
     Agent agent(consul);
 
-    auto selfMember = agent.self().second;
+    auto self = agent.self();
+    auto & selfConfig = self.first;
+    CHECK(!selfConfig.datacenter.empty());
+    CHECK(!selfConfig.nodeName.empty());
+    CHECK(!selfConfig.nodeId.empty());
+    CHECK(!selfConfig.version.empty());
+    // seems like selfConfig.revision can be empty
+
+    auto & selfMember = self.second;
     CHECK(!selfMember.name.empty());
     CHECK(!selfMember.address.empty());
     CHECK(selfMember.port);
@@ -40,6 +48,8 @@ TEST_CASE("agent.self", "[consul][agent][config][self]")
     CHECK(selfMember.delegateMin);
     CHECK(selfMember.delegateMax);
     CHECK(selfMember.delegateCur);
+
+    CHECK(selfConfig.nodeName == selfMember.name);
 }
 
 TEST_CASE("agent.members", "[consul][agent][config][members]")


### PR DESCRIPTION
Makes /agent/self return Config object. 

Not sure what was up with the _"TODO: use boost::ptree"_ comment, [looks like](https://www.consul.io/api-docs/agent#read-configuration) this part is pretty consistent so there's no point to avoid using a struct here.

> The Config element contains a subset of the configuration and its format will not change in a backwards incompatible way between releases. 