### PR TITLE
Pass access token via headers

### DIFF
--- a/include/ppconsul/consul.h
+++ b/include/ppconsul/consul.h
@@ -232,7 +232,7 @@ namespace ppconsul {
         template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
         http::RequestHeaders makeHeaders(const Params&... params) const
         {
-            auto headers = http::RequestHeaders{};
+            http::RequestHeaders headers;
             headers.emplace(http::Token_Header_Name, kwargs::get_opt(kw::token, defaultToken(), params...));
             return headers;
         }

--- a/include/ppconsul/consul.h
+++ b/include/ppconsul/consul.h
@@ -232,7 +232,9 @@ namespace ppconsul {
         template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
         http::RequestHeaders makeHeaders(const Params&... params) const
         {
-            return { { http::Token_Header_Name, kwargs::get_opt(kw::token, defaultToken(), params...) } };
+            auto headers = http::RequestHeaders{};
+            headers.emplace(http::Token_Header_Name, kwargs::get_opt(kw::token, defaultToken(), params...));
+            return headers;
         }
 
         Response<std::string> get_impl(http::Status& status, const std::string& path,

--- a/include/ppconsul/http/http_client.h
+++ b/include/ppconsul/http/http_client.h
@@ -10,9 +10,11 @@
 #include <ppconsul/response.h>
 #include <tuple>
 #include <string>
+#include <map>
 
 
 namespace ppconsul { namespace http {
+    const std::string Token_Header_Name("X-Consul-Token");
 
     struct TlsConfig
     {
@@ -34,17 +36,26 @@ namespace ppconsul { namespace http {
         const char *keyPass;
     };
 
+    using RequestHeaders = std::map<std::string, std::string>;
+
     class HttpClient
     {
     public:
+        using GetResponse = std::tuple<Status, ResponseHeaders, std::string>;
+        using PutResponse = std::pair<Status, std::string>;
+        using DelResponse = std::pair<Status, std::string>;
+
         // Returns {HttpStatus, headers, body}
-        virtual std::tuple<Status, ResponseHeaders, std::string> get(const std::string& path, const std::string& query) = 0;
+        virtual GetResponse get(const std::string& path, const std::string& query,
+                                const RequestHeaders & headers = RequestHeaders{}) = 0;
 
         // Returns {HttpStatus, body}
-        virtual std::pair<Status, std::string> put(const std::string& path, const std::string& query, const std::string& data) = 0;
+        virtual PutResponse put(const std::string& path, const std::string& query, const std::string& data,
+                                const RequestHeaders & headers = RequestHeaders{}) = 0;
 
         // Returns {HttpStatus, body}
-        virtual std::pair<Status, std::string> del(const std::string& path, const std::string& query) = 0;
+        virtual DelResponse del(const std::string& path, const std::string& query,
+                                const RequestHeaders & headers = RequestHeaders{}) = 0;
 
         virtual ~HttpClient() {};
     };

--- a/src/curl/http_client.h
+++ b/src/curl/http_client.h
@@ -35,6 +35,8 @@ namespace ppconsul { namespace curl {
         };
     }
 
+    using CurlHeaderList = std::unique_ptr<curl_slist, detail::CurlSListDeleter>;
+
     class CurlHttpClient: public ppconsul::http::HttpClient
     {
     public:
@@ -76,7 +78,7 @@ namespace ppconsul { namespace curl {
 
         std::string m_endpoint;
         std::unique_ptr<CURL, detail::CurlEasyDeleter> m_handle;
-        std::unique_ptr<curl_slist, detail::CurlSListDeleter> m_headers;
+        CurlHeaderList m_headers;
         char m_errBuffer[CURL_ERROR_SIZE]; // Replace with unique_ptr<std::array<char, CURL_ERROR_SIZE>> if moving is needed
     };
 


### PR DESCRIPTION
Closes #39

Implementation adds passing headers to HttpClient interface. kw::token param is explicitly excluded from the query on every request and passed as X-Consul-Token header instead. 