### PR TITLE
Add typed interface for KV store

### DIFF
--- a/include/ppconsul/kv.h
+++ b/include/ppconsul/kv.h
@@ -475,7 +475,7 @@ namespace ppconsul { namespace kv {
         template<class T, class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
         bool unlock(const std::string& key, const std::string& session, const T& value, const Params&... params) const
         {
-            return unlock(key, session, value, params...);
+            return unlock(key, session, boost::lexical_cast<std::string>(value), params...);
         }
 
         // Perform a series of operations as a transaction.


### PR DESCRIPTION
This PR adds typed interface for KV methods making it possible to call `get<double>(key)` and `set(key, some_double)` using boost::lexical_cast. It is also possible to pass user classes if they are Input/Output Streamable. KeyValue struct still stores string value but now has a `get<T>()` method. CAS and lock/unlock methods are also implemented, transactions are still string value only.

There are also some (honestly, random) tests.