### PR TITLE
Add Coordinate endpoint

### DIFF
--- a/include/ppconsul/consul.h
+++ b/include/ppconsul/consul.h
@@ -103,6 +103,8 @@ namespace ppconsul {
 
     const char Default_Server_Endpoint[] = "http://127.0.0.1:8500";
 
+    const char All_Segments[] = "_all";
+
     using CancellationCallback = std::function<bool()>;
 
     using HttpClientFactory = std::function<std::unique_ptr<http::HttpClient>(const std::string& endpoint,

--- a/include/ppconsul/coordinate.h
+++ b/include/ppconsul/coordinate.h
@@ -1,0 +1,134 @@
+//  Copyright (c) 2014-2020 Andrey Upadyshev <oliora@gmail.com>
+//
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# pragma once
+
+#include "ppconsul/consul.h"
+#include "ppconsul/helpers.h"
+#include "ppconsul/types.h"
+
+namespace ppconsul { namespace coordinate {
+
+    struct Value
+    {
+        double adjustment;
+        double error;
+        double height;
+        std::vector<double> vec;
+    };
+
+    struct Node
+    {
+        std::string node;
+        std::string segment;
+        Value coord;
+    };
+
+    struct Datacenter
+    {
+        std::string datacenter;
+        std::string areaId;
+        std::vector<Node> coordinates;
+    };
+
+    namespace kw {
+        using ppconsul::kw::consistency;
+        using ppconsul::kw::block_for;
+        using ppconsul::kw::dc;
+
+        KWARGS_KEYWORD(segment, std::string)
+
+        namespace groups {
+            KWARGS_KEYWORDS_GROUP(get, (consistency, dc, block_for))
+        }
+    }
+
+    namespace impl {
+        std::vector<Datacenter> parseDatacenters(const std::string& json);
+        std::vector<Node> parseNodes(const std::string& json);
+        Node parseNode(const std::string& json);
+    }
+
+    class Coordinate
+    {
+    public:
+        template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
+        explicit Coordinate(Consul& consul, const Params&... params)
+        : m_consul(consul)
+        , m_defaultConsistency(kwargs::get_opt(kw::consistency, Consistency::Default, params...))
+        , m_defaultDc(kwargs::get_opt(kw::dc, std::string(), params...))
+        {
+            KWARGS_CHECK_IN_LIST(Params, (kw::consistency, kw::dc))
+        }
+        
+        std::vector<Datacenter> datacenters() const
+        {
+            return impl::parseDatacenters(m_consul.get("/v1/coordinate/datacenters"));
+        }
+
+        // Result contains both headers and data.
+        // Allowed parameters:
+        // - segment
+        // - group::get
+        template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
+        Response<std::vector<Node>> nodes(WithHeaders, const Params&... params) const;
+
+        // Result contains data only.
+        // Allowed parameters:
+        // - segment
+        // - group::get
+        template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
+        std::vector<Node> nodes(const Params&... params) const
+        {
+            return std::move(nodes(withHeaders, params...).data());
+        }
+
+        // Throws NotFoundError if node does not exist
+        // Result contains both headers and data.
+        // Allowed parameters:
+        // - group::get
+        template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
+        Response<std::vector<Node>> node(WithHeaders, const std::string& name, const Params&... params) const;
+
+        // Throws NotFoundError if node does not exist
+        // Result contains data only.
+        // Allowed parameters:
+        // - group::get
+        template<class... Params, class = kwargs::enable_if_kwargs_t<Params...>>
+        std::vector<Node> node(const std::string& name, const Params&... params) const
+        {
+            return std::move(node(withHeaders, name, params...).data());
+        }
+
+    private:
+        Consul& m_consul;
+
+        Consistency m_defaultConsistency;
+        std::string m_defaultDc;
+    };
+
+    // Implementation
+
+    template<class... Params, class>
+    Response<std::vector<Node>> Coordinate::nodes(WithHeaders, const Params&... params) const
+    {
+        KWARGS_CHECK_IN_LIST(Params, (kw::groups::get, kw::segment));
+        auto r = m_consul.get(withHeaders, "/v1/coordinate/nodes",
+            kw::consistency = m_defaultConsistency, kw::dc = m_defaultDc,
+            params...);
+        return makeResponse(r.headers(), impl::parseNodes(r.data()));
+    }
+
+    template<class... Params, class>
+    Response<std::vector<Node>> Coordinate::node(WithHeaders, const std::string& name, const Params&... params) const
+    {
+        KWARGS_CHECK_IN_LIST(Params, (kw::groups::get));
+        auto r = m_consul.get(withHeaders, "/v1/coordinate/node/" + helpers::encodeUrl(name),
+            kw::consistency = m_defaultConsistency, kw::dc = m_defaultDc,
+            params...);
+        return makeResponse(r.headers(), impl::parseNodes(r.data()));
+    }
+}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS
     agent.h
     catalog.h
     consul.h
+    coordinate.h
     error.h
     health.h
     helpers.h
@@ -32,6 +33,7 @@ set(SOURCES
     agent.cpp
     catalog.cpp
     consul.cpp
+    coordinate.cpp
     helpers.cpp
     health.cpp
     client_pool.cpp

--- a/src/coordinate.cpp
+++ b/src/coordinate.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2014-2020 Andrey Upadyshev <oliora@gmail.com>
+//
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include "ppconsul/coordinate.h"
+#include "s11n_types.h"
+
+
+namespace json11 {
+    void load(const json11::Json& src, ppconsul::coordinate::Value& dst)
+    {
+        using ppconsul::s11n::load;
+
+        load(src, dst.adjustment, "Adjustment");
+        load(src, dst.error, "Error");
+        load(src, dst.height, "Height");
+        load(src, dst.vec, "Vec");
+    }
+
+    void load(const json11::Json& src, ppconsul::coordinate::Node& dst)
+    {
+        using ppconsul::s11n::load;
+
+        load(src, dst.node, "Node");
+        load(src, dst.segment, "Segment");
+        load(src, dst.coord, "Coord");
+    }
+
+    void load(const json11::Json& src, ppconsul::coordinate::Datacenter& dst)
+    {
+        using ppconsul::s11n::load;
+
+        load(src, dst.datacenter, "Datacenter");
+        load(src, dst.areaId, "AreaID");
+        load(src, dst.coordinates, "Coordinates");
+    }
+}
+
+namespace ppconsul { namespace coordinate {
+
+namespace impl {
+
+    std::vector<Datacenter> parseDatacenters(const std::string& json)
+    {
+        return s11n::parseJson<std::vector<Datacenter>>(json);
+    }
+
+    std::vector<Node> parseNodes(const std::string& json)
+    {
+        return s11n::parseJson<std::vector<Node>>(json);
+    }
+
+    Node parseNode(const std::string& json)
+    {
+        return s11n::parseJson<Node>(json);
+    }
+
+}
+
+}}

--- a/src/s11n.h
+++ b/src/s11n.h
@@ -65,6 +65,11 @@ namespace ppconsul { namespace s11n {
         dst = static_cast<uint64_t>(src.number_value());
     }
 
+    inline void load(const Json& src, double& dst)
+    {
+        dst = src.number_value();
+    }
+
     inline void load(const Json& src, std::chrono::minutes& dst)
     {
         dst = std::chrono::minutes(static_cast<int>(src.number_value()));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(unittests) # to run unittests before consul ones
 add_subdirectory(consul)
 add_subdirectory(agent)
 add_subdirectory(catalog)
+add_subdirectory(coordinate)
 add_subdirectory(kv)
 add_subdirectory(sessions)
 add_subdirectory(status)

--- a/tests/coordinate/CMakeLists.txt
+++ b/tests/coordinate/CMakeLists.txt
@@ -1,0 +1,13 @@
+#  Copyright (c) 2014-2020 Andrey Upadyshev <oliora@gmail.com>
+#
+#  Use, modification and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+project(coordinate-tests)
+add_executable(${PROJECT_NAME}
+    ../main.cpp
+    coordinate_tests.cpp
+)
+link_test_libs(${PROJECT_NAME})
+add_catch_test(${PROJECT_NAME})

--- a/tests/coordinate/coordinate_tests.cpp
+++ b/tests/coordinate/coordinate_tests.cpp
@@ -1,0 +1,155 @@
+//  Copyright (c) 2014-2020 Andrey Upadyshev <oliora@gmail.com>
+//
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <catch/catch.hpp>
+
+#include "ppconsul/coordinate.h"
+#include "ppconsul/agent.h"
+#include "test_consul.h"
+
+#include <algorithm>
+
+using namespace ppconsul::coordinate;
+using ppconsul::agent::Agent;
+
+namespace {
+    const auto Non_Existing_Node_Name = "D0087276-8F85-4612-AC88-8871DB15B2A7";
+
+    // Verifies that all nodes have the same dimensionality
+    bool sameDim(const std::vector<Node>& nodes)
+    {
+        if (nodes.empty())
+        {
+            return true;
+        }
+
+        auto dim = nodes.front().coord.vec.size();
+        
+        return std::none_of(
+            nodes.begin(), nodes.end(),
+            [dim](const auto& node)
+            {
+                return (node.coord.vec.size() != dim);
+            }
+        );
+    }
+
+}
+
+TEST_CASE("coordinate.datacenters", "[consul][coordinate]")
+{
+    auto consul = create_test_consul();
+    Coordinate coordinate(consul);
+
+    auto dcs = coordinate.datacenters();
+
+    REQUIRE_FALSE(dcs.empty());
+    auto it = std::find_if(dcs.begin(), dcs.end(), [&](const Datacenter& op){
+        return op.datacenter== get_test_datacenter();
+    });
+    CHECK(it != dcs.end());
+
+    for (const auto& d : dcs)
+    {
+        CHECK_FALSE(d.datacenter.empty());
+        CHECK_FALSE(d.areaId.empty());
+
+        REQUIRE_FALSE(d.coordinates.empty());
+        for (const auto& node : d.coordinates)
+        {
+            CHECK_FALSE(node.node.empty());
+            CHECK_FALSE(node.coord.vec.empty());
+        }
+        CHECK(sameDim(d.coordinates));
+    }
+}
+
+TEST_CASE("coordinate.nodes", "[consul][coordinate]")
+{
+    auto consul = create_test_consul();
+    Coordinate coordinate(consul);
+
+    const auto selfMember = Agent(consul).self().second;
+
+    auto nodes = coordinate.nodes();
+
+    REQUIRE_FALSE(nodes.empty());
+
+    auto it = std::find_if(nodes.begin(), nodes.end(), [&](const Node& op){
+        return op.node == selfMember.name;
+    });
+    REQUIRE(it != nodes.end());
+
+    for (const auto& node : nodes)
+    {
+        CHECK_FALSE(node.node.empty());
+        CHECK_FALSE(node.coord.vec.empty());
+    }
+    CHECK(sameDim(nodes));
+}
+
+TEST_CASE("coordinate.node", "[consul][coordinate]")
+{
+    auto consul = create_test_consul();
+    Coordinate coordinate(consul);
+
+    const auto selfMember = Agent(consul).self().second;
+
+    std::cout << selfMember.name << std::endl;
+    auto node = coordinate.node(selfMember.name);
+
+    REQUIRE(node.size() >= 1);
+    for (const auto& nodeRec : node)
+    {
+        CHECK(nodeRec.node == selfMember.name);
+        CHECK_FALSE(nodeRec.coord.vec.empty());
+    }
+    CHECK(sameDim(node));
+
+    CHECK_THROWS_AS(coordinate.node(Non_Existing_Node_Name), ppconsul::NotFoundError);
+}
+
+TEST_CASE("coordinate.node_float_parse", "[consul][coordinate][parse]")
+{
+    const std::string json("{"
+        "\"Node\": \"core-1\","
+        "\"Segment\": \"segment\","
+        "\"Coord\": {"
+            "\"Vec\": ["
+                "-0.0030908182083252632,"
+                "-0.0034924296469496137,"
+                "0.004027661974926579,"
+                "0.009441736044369261,"
+                "0.009120584954036386,"
+                "0.005945711502389089,"
+                "-0.005375781324440643,"
+                "0.002691224249211683"
+            "],"
+            "\"Error\": 0.33682855812450196,"
+            "\"Adjustment\": -8.957602083707684e-05,"
+            "\"Height\": 0.0005342546178363255"
+        "}"
+    "}");
+
+    auto node = impl::parseNode(json);
+
+    CHECK(node.node == "core-1");
+    CHECK(node.segment == "segment");
+
+    REQUIRE(node.coord.vec.size() == 8);
+    CHECK(node.coord.vec[0] == Approx(-0.0030908182083252632));
+    CHECK(node.coord.vec[1] == Approx(-0.0034924296469496137));
+    CHECK(node.coord.vec[2] == Approx(0.004027661974926579));
+    CHECK(node.coord.vec[3] == Approx(0.009441736044369261));
+    CHECK(node.coord.vec[4] == Approx(0.009120584954036386));
+    CHECK(node.coord.vec[5] == Approx(0.005945711502389089));
+    CHECK(node.coord.vec[6] == Approx(-0.005375781324440643));
+    CHECK(node.coord.vec[7] == Approx(0.002691224249211683));
+
+    CHECK(node.coord.error == Approx(0.33682855812450196));
+    CHECK(node.coord.adjustment == Approx(-0.00008957602083707684));
+    CHECK(node.coord.height == Approx(0.0005342546178363255));
+}

--- a/tests/coordinate/coordinate_tests.cpp
+++ b/tests/coordinate/coordinate_tests.cpp
@@ -28,11 +28,11 @@ namespace {
 
         auto dim = nodes.front().coord.vec.size();
         
-        return std::none_of(
+        return std::all_of(
             nodes.begin(), nodes.end(),
             [dim](const auto& node)
             {
-                return (node.coord.vec.size() != dim);
+                return (node.coord.vec.size() == dim);
             }
         );
     }
@@ -98,7 +98,6 @@ TEST_CASE("coordinate.node", "[consul][coordinate]")
 
     const auto selfMember = Agent(consul).self().second;
 
-    std::cout << selfMember.name << std::endl;
     auto node = coordinate.node(selfMember.name);
 
     REQUIRE(node.size() >= 1);
@@ -109,7 +108,7 @@ TEST_CASE("coordinate.node", "[consul][coordinate]")
     }
     CHECK(sameDim(node));
 
-    CHECK_THROWS_AS(coordinate.node(Non_Existing_Node_Name), ppconsul::NotFoundError);
+    CHECK(coordinate.node(Non_Existing_Node_Name).empty());
 }
 
 TEST_CASE("coordinate.node_float_parse", "[consul][coordinate][parse]")


### PR DESCRIPTION
This PR implements [coordinate](https://www.consul.io/api-docs/coordinate) endpoint queries:

- `/coordinate/datacenters`
- `/coordinate/nodes`
- `/coordinate/node/:node`

It **doesn't** add an implementation for `/coordinate/update`.

## `/coordinate/node/:node`

### Returning `std::vector`

I don't quite like returning a vector of nodes in `/coordinate/node/:node`, but the endpoint returns an array for this request (see [Sample Response](https://www.consul.io/api-docs/coordinate#sample-response-1))

> In Consul Enterprise, this may include multiple coordinates for the same node, each marked with a different Segment. Coordinates are only compatible within the same segment. 

I'm not sure how `ppconsul` handles Enterprise features. It's not required in my use-case so it's up to you.  
Should we leave it like that (i.e. return a vector)?

### NotFoundError handling

Currently `/coordinate/node/:node` throws `NotFoundError` if node does not exist (because of the API responding with 404).   
Should we catch it and return empty vector instead?

## `/agent/self`

This request [also returns](https://www.consul.io/api-docs/agent#sample-response-2) Coordinate block, should we implement it aswell?
Although it seems to be difficult without breaking existing interface. Maybe by adding coordinates to `Member` struct?