### PR TITLE
Remove the use of auto in the lambda parameter declaration

### DIFF
--- a/tests/coordinate/coordinate_tests.cpp
+++ b/tests/coordinate/coordinate_tests.cpp
@@ -30,7 +30,7 @@ namespace {
         
         return std::all_of(
             nodes.begin(), nodes.end(),
-            [dim](const auto& node)
+            [dim](const Node& node)
             {
                 return (node.coord.vec.size() == dim);
             }


### PR DESCRIPTION
This PR removes the auto lambda parameter from the new coordinate test in order to keep this compatible with the older c++11 standard.