### PR TITLE
Add coordinates on Self query (BREAKING!)

### DIFF
--- a/include/ppconsul/agent.h
+++ b/include/ppconsul/agent.h
@@ -44,6 +44,13 @@ namespace ppconsul { namespace agent {
         std::string version;
     };
 
+    struct SelfInfo
+    {
+        Config config;
+        Member member;
+        Coordinate coord;
+    };
+
     struct TtlCheck
     {
         TtlCheck() = default;
@@ -174,7 +181,7 @@ namespace ppconsul { namespace agent {
         struct ServiceRegistrationData;
 
         std::vector<Member> parseMembers(const std::string& json);
-        std::pair<Config, Member> parseSelf(const std::string& json);
+        SelfInfo parseSelf(const std::string& json);
         std::map<std::string, CheckInfo> parseChecks(const std::string& json);
         std::map<std::string, ServiceInfo> parseServices(const std::string& json);
 
@@ -203,7 +210,7 @@ namespace ppconsul { namespace agent {
             return impl::parseMembers(m_consul.get("/v1/agent/members", kw::pool = pool));
         }
         
-        std::pair<Config, Member> self() const
+        SelfInfo self() const
         {
             return impl::parseSelf(m_consul.get("/v1/agent/self"));
         }

--- a/include/ppconsul/coordinate.h
+++ b/include/ppconsul/coordinate.h
@@ -12,13 +12,7 @@
 
 namespace ppconsul { namespace coordinate {
 
-    struct Value
-    {
-        double adjustment;
-        double error;
-        double height;
-        std::vector<double> vec;
-    };
+    using Value = ppconsul::Coordinate;
 
     struct Node
     {

--- a/include/ppconsul/types.h
+++ b/include/ppconsul/types.h
@@ -76,6 +76,14 @@ namespace ppconsul {
         Metadata meta;
     };
 
+    struct Coordinate
+    {
+        double adjustment;
+        double error;
+        double height;
+        std::vector<double> vec;
+    };
+
     struct WithHeaders {};
     const WithHeaders withHeaders = WithHeaders();
 

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -8,19 +8,15 @@
 #include "ppconsul/agent.h"
 #include "s11n_types.h"
 
-namespace json11 {
-    inline void load(const json11::Json& src, std::pair<ppconsul::agent::Config, ppconsul::agent::Member>& dst)
-    {
-        using ppconsul::s11n::load;
-
-        load(src, dst.first, "Config");
-        load(src, dst.second, "Member");
-    }
-}
-
-
 namespace ppconsul { namespace agent {
     using s11n::load;
+
+    inline void load(const json11::Json& src, SelfInfo& dst)
+    {
+        load(src, dst.config, "Config");
+        load(src, dst.member, "Member");
+        load(src, dst.coord, "Coord");
+    }
 
     void load(const s11n::Json& src, Config& dst)
     {
@@ -139,9 +135,9 @@ namespace impl {
         return s11n::parseJson<std::vector<Member>>(json);
     }
 
-    std::pair<Config, Member> parseSelf(const std::string& json)
+    SelfInfo parseSelf(const std::string& json)
     {
-        return s11n::parseJson<std::pair<Config, Member>>(json);
+        return s11n::parseJson<SelfInfo>(json);
     }
 
     std::map<std::string, CheckInfo> parseChecks(const std::string& json)

--- a/src/coordinate.cpp
+++ b/src/coordinate.cpp
@@ -8,18 +8,7 @@
 #include "ppconsul/coordinate.h"
 #include "s11n_types.h"
 
-
-namespace json11 {
-    void load(const json11::Json& src, ppconsul::coordinate::Value& dst)
-    {
-        using ppconsul::s11n::load;
-
-        load(src, dst.adjustment, "Adjustment");
-        load(src, dst.error, "Error");
-        load(src, dst.height, "Height");
-        load(src, dst.vec, "Vec");
-    }
-
+namespace ppconsul { namespace coordinate {
     void load(const json11::Json& src, ppconsul::coordinate::Node& dst)
     {
         using ppconsul::s11n::load;
@@ -37,9 +26,6 @@ namespace json11 {
         load(src, dst.areaId, "AreaID");
         load(src, dst.coordinates, "Coordinates");
     }
-}
-
-namespace ppconsul { namespace coordinate {
 
 namespace impl {
 

--- a/src/s11n_types.h
+++ b/src/s11n_types.h
@@ -60,4 +60,14 @@ namespace ppconsul {
         load(src, dst.serviceName, "ServiceName");
     }
 
+    inline void load(const json11::Json& src, Coordinate& dst)
+    {
+        using s11n::load;
+
+        load(src, dst.adjustment, "Adjustment");
+        load(src, dst.error, "Error");
+        load(src, dst.height, "Height");
+        load(src, dst.vec, "Vec");
+    }
+
 }

--- a/tests/agent/agent_checks_tests.cpp
+++ b/tests/agent/agent_checks_tests.cpp
@@ -63,7 +63,7 @@ TEST_CASE("agent.ttl_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes.empty());
@@ -81,7 +81,7 @@ TEST_CASE("agent.ttl_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes == "some notes");
@@ -99,7 +99,7 @@ TEST_CASE("agent.ttl_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at(Unique_Id);
 
         CHECK(c.id == Unique_Id);
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes == "other notes");
@@ -117,7 +117,7 @@ TEST_CASE("agent.ttl_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes.empty());
@@ -146,7 +146,7 @@ TEST_CASE("agent.script_check_registration_0_x", "[!hide][consul][agent][checks]
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -169,7 +169,7 @@ TEST_CASE("agent.script_check_registration_0_x", "[!hide][consul][agent][checks]
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes == "the notes");
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -188,7 +188,7 @@ TEST_CASE("agent.script_check_registration_0_x", "[!hide][consul][agent][checks]
         const auto & c = checks.at(Unique_Id);
 
         CHECK(c.id == Unique_Id);
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes == "the notes");
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -206,7 +206,7 @@ TEST_CASE("agent.script_check_registration_0_x", "[!hide][consul][agent][checks]
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -234,7 +234,7 @@ TEST_CASE("agent.command_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -257,7 +257,7 @@ TEST_CASE("agent.command_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at("check1");
 
         CHECK(c.id == "check1");
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes == "the notes");
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -276,7 +276,7 @@ TEST_CASE("agent.command_check_registration", "[consul][agent][checks]")
         const auto & c = checks.at(Unique_Id);
 
         CHECK(c.id == Unique_Id);
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(c.name == "check1");
         CHECK(c.notes == "the notes");
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name

--- a/tests/agent/agent_services_tests.cpp
+++ b/tests/agent/agent_services_tests.cpp
@@ -133,7 +133,7 @@ TEST_CASE("agent.service_registration", "[consul][agent][services]")
         const auto & c = checks.at(serviceCheckId("service1"));
 
         CHECK(c.id == serviceCheckId("service1"));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes.empty());
@@ -170,7 +170,7 @@ TEST_CASE("agent.service_registration", "[consul][agent][services]")
         const auto & c = checks.at(serviceCheckId(Unique_Id));
 
         CHECK(c.id == serviceCheckId(Unique_Id));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes.empty());
@@ -198,7 +198,7 @@ TEST_CASE("agent.service_registration", "[consul][agent][services]")
         const auto & c = checks.at(serviceCheckId("service1"));
 
         CHECK(c.id == serviceCheckId("service1"));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.status != CheckStatus::Passing);
         CHECK(c.notes.empty());
@@ -238,7 +238,7 @@ TEST_CASE("agent.service_registration_script_check_0_x", "[!hide][consul][agent]
         const auto & c = checks.at(serviceCheckId("service1"));
 
         CHECK(c.id == serviceCheckId("service1"));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -275,7 +275,7 @@ TEST_CASE("agent.service_registration_script_check_0_x", "[!hide][consul][agent]
         const auto & c = checks.at(serviceCheckId(Unique_Id));
 
         CHECK(c.id == serviceCheckId(Unique_Id));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -314,7 +314,7 @@ TEST_CASE("agent.service_registration_command_check", "[consul][agent][services]
         const auto & c = checks.at(serviceCheckId("service1"));
 
         CHECK(c.id == serviceCheckId("service1"));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name
@@ -351,7 +351,7 @@ TEST_CASE("agent.service_registration_command_check", "[consul][agent][services]
         const auto & c = checks.at(serviceCheckId(Unique_Id));
 
         CHECK(c.id == serviceCheckId(Unique_Id));
-        CHECK(c.node == agent.self().second.name);
+        CHECK(c.node == agent.self().member.name);
         CHECK(!c.name.empty());
         CHECK(c.notes.empty());
         CHECK(c.status != CheckStatus::Passing);    // because of Non_Existing_Script_Name

--- a/tests/coordinate/coordinate_tests.cpp
+++ b/tests/coordinate/coordinate_tests.cpp
@@ -72,14 +72,14 @@ TEST_CASE("coordinate.nodes", "[consul][coordinate]")
     auto consul = create_test_consul();
     Coordinate coordinate(consul);
 
-    const auto selfMember = Agent(consul).self().second;
+    auto self = Agent(consul).self();
 
     auto nodes = coordinate.nodes();
 
     REQUIRE_FALSE(nodes.empty());
 
     auto it = std::find_if(nodes.begin(), nodes.end(), [&](const Node& op){
-        return op.node == selfMember.name;
+        return op.node == self.member.name;
     });
     REQUIRE(it != nodes.end());
 
@@ -96,14 +96,14 @@ TEST_CASE("coordinate.node", "[consul][coordinate]")
     auto consul = create_test_consul();
     Coordinate coordinate(consul);
 
-    const auto selfMember = Agent(consul).self().second;
+    auto self = Agent(consul).self();
 
-    auto node = coordinate.node(selfMember.name);
+    auto node = coordinate.node(self.member.name);
 
     REQUIRE(node.size() >= 1);
     for (const auto& nodeRec : node)
     {
-        CHECK(nodeRec.node == selfMember.name);
+        CHECK(nodeRec.node == self.member.name);
         CHECK_FALSE(nodeRec.coord.vec.empty());
     }
     CHECK(sameDim(node));


### PR DESCRIPTION
Closes #68

_BREAKING CHANGE: Agent::self() now returns SelfInfo with three members, which will basically break any code using this call_